### PR TITLE
Edit user-folder link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Welcome to the Binary Ninja Community Themes repository.
 
 ## Using themes
 
-To install a single theme, simply download the `bntheme` file into the `themes/` or `community-themes/` subfolders of your [user folder](https://docs.binary.ninja/getting-started.html#user-folder) (you might need to make the folder).
+To install a single theme, simply download the `bntheme` file into the `themes/` or `community-themes/` subfolders of your [user folder](https://docs.binary.ninja/guide/index.html#user-folder) (you might need to make the folder).
 
-Alternatively, clone the entire community repository into a folder called `community-themes` inside of your [user folder](https://docs.binary.ninja/getting-started.html#user-folder) to be able to choose any community theme.
+Alternatively, clone the entire community repository into a folder called `community-themes` inside of your [user folder](https://docs.binary.ninja/guide/index.html#user-folder) to be able to choose any community theme.
 
 Once installed, you can choose your desired theme via the `ui.theme` setting (open [Settings](https://docs.binary.ninja/getting-started.html#settings) and search for "Theme").
 


### PR DESCRIPTION
The link in the README.md for the `user-folder` was `https://docs.binary.ninja/getting-started.html#user-folder`, but due to the "User Manual" being moved from "Getting started", the link is broken.
The correct link should be `https://docs.binary.ninja/guide/index.html#user-folder`.

